### PR TITLE
V1.6.5

### DIFF
--- a/battery-card/battery-card-example.yaml
+++ b/battery-card/battery-card-example.yaml
@@ -116,7 +116,7 @@ cards:
         tabs:
           - attributes:
               label: General
-              icon: mdi:chart-bell-curve-cumulative
+              icon: mdi:amplifier
             card:
               type: vertical-stack
               cards:
@@ -250,8 +250,8 @@ cards:
                     title: inside
                     value: inside
           - attributes:
-              label: Sensors
-              icon: mdi:eye-check
+              label: Other
+              icon: mdi:eye
             card:
               type: grid
               no_card: true
@@ -315,6 +315,10 @@ cards:
                 - type: tile
                   entity: binary_sensor.powerwall_battery_deep_sleep_mode
                   name: Deep Sleep
+                  no_card: true
+                - type: tile
+                  entity: button.powerwall_battery_enter_deep_sleep
+                  name: Enter Deep Sleep
                   no_card: true
                   icon_tap_action:
                     action: more-info

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -6,7 +6,7 @@ esphome:
     - "${device_name}/helpers"
   project:
     name: "odya.esphome-smart-battery"
-    version: 1.6.4
+    version: 1.6.5
 
 packages:
   bms: !include {

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -6,7 +6,7 @@ esphome:
     - "${device_name}/helpers"
   project:
     name: "odya.esphome-smart-battery"
-    version: 1.6.3
+    version: 1.6.4
 
 packages:
   bms: !include {

--- a/src/modules/bms.yaml
+++ b/src/modules/bms.yaml
@@ -65,6 +65,7 @@ sensor:
     current:
       name: "Current"
       id: current
+      accuracy_decimals: 2
       filters: &numfilters
         - timeout: 60s
     power:

--- a/src/modules/deep_sleep.yaml
+++ b/src/modules/deep_sleep.yaml
@@ -21,6 +21,7 @@ deep_sleep:
     number: ${button1_pin}
     inverted: true
     mode: INPUT_PULLUP
+    allow_other_uses: true
   wakeup_pin_mode: INVERT_WAKEUP
 
 script:

--- a/src/modules/deep_sleep.yaml
+++ b/src/modules/deep_sleep.yaml
@@ -67,4 +67,8 @@ binary_sensor:
     lambda: |-
       return id(deep_sleep_mode);
 
-    
+button:
+  - platform: template
+    name: Enter Deep Sleep
+    on_press:
+      - script.execute: deep_sleep_mode_on

--- a/src/modules/display.yaml
+++ b/src/modules/display.yaml
@@ -51,12 +51,10 @@ binary_sensor:
     pin:
       number: ${button1_pin}
       inverted: true
-      mode:
-        input: true
-        pullup: true
+      mode: INPUT_PULLUP
     entity_category: diagnostic
     filters:
-      - delayed_on_off: 100ms
+      - delayed_on_off: 200ms
     on_press:
       then:
         - lambda: |-
@@ -66,7 +64,7 @@ binary_sensor:
             }
     on_click:
       - min_length: 100ms
-        max_length: 3000ms
+        max_length: 4999ms
         then:
           - lambda: ESP_LOGI("display_button", "Short Clicked");
           - script.execute: wake_scroll_screens_sleep

--- a/src/modules/display.yaml
+++ b/src/modules/display.yaml
@@ -52,6 +52,7 @@ binary_sensor:
       number: ${button1_pin}
       inverted: true
       mode: INPUT_PULLUP
+      allow_other_uses: true
     entity_category: diagnostic
     filters:
       - delayed_on_off: 200ms


### PR DESCRIPTION
### Fixed compatibility with new versions of EspHome [commit](https://github.com/odya/esphome-smart-battery/commit/4540613522624675483c9fe65b1e5b310f49fbec)

### Current accuracy_decimals set to 2 [commit](https://github.com/odya/esphome-smart-battery/commit/6c06327f54ea0485f614874ca5656e54f50eb49e)

### Deep sleep mode update [commit](https://github.com/odya/esphome-smart-battery/commit/a86f242145e80d9449d21f62e8d0837e5d029030) 

- Remote button for enter deep sleep
- Card updated. Added remote button, fixed icons
- HW button fixes